### PR TITLE
Create new JSON-RPC provider instance fix

### DIFF
--- a/docs/tutorials/sendGasless.md
+++ b/docs/tutorials/sendGasless.md
@@ -74,7 +74,7 @@ const config = {
 };
 
 // Generate EOA from private key using ethers.js
-let provider = new ethers.JsonRpcProvider(config.rpcUrl);
+let provider = new ethers.providers.JsonRpcProvider(config.rpcUrl);
 let signer = new ethers.Wallet(config.privateKey, provider);
 
 // Create Biconomy Smart Account instance

--- a/docs/tutorials/sendGasless.md
+++ b/docs/tutorials/sendGasless.md
@@ -74,7 +74,7 @@ const config = {
 };
 
 // Generate EOA from private key using ethers.js
-let provider = new ethers.JsonRpcProvider(config.rpcUrl)();
+let provider = new ethers.JsonRpcProvider(config.rpcUrl);
 let signer = new ethers.Wallet(config.privateKey, provider);
 
 // Create Biconomy Smart Account instance

--- a/docs/tutorials/sendSimpleTransaction.md
+++ b/docs/tutorials/sendSimpleTransaction.md
@@ -68,7 +68,7 @@ const config = {
 };
 
 // Generate EOA from private key using ethers.js
-let provider = new ethers.JsonRpcProvider(config.rpcUrl)();
+let provider = new ethers.JsonRpcProvider(config.rpcUrl);
 let signer = new ethers.Wallet(config.privateKey, provider);
 
 // Create Biconomy Smart Account instance

--- a/docs/tutorials/sendSimpleTransaction.md
+++ b/docs/tutorials/sendSimpleTransaction.md
@@ -68,7 +68,7 @@ const config = {
 };
 
 // Generate EOA from private key using ethers.js
-let provider = new ethers.JsonRpcProvider(config.rpcUrl);
+let provider = new ethers.providers.JsonRpcProvider(config.rpcUrl);
 let signer = new ethers.Wallet(config.privateKey, provider);
 
 // Create Biconomy Smart Account instance

--- a/docs/tutorials/sendTransactionsBatch.md
+++ b/docs/tutorials/sendTransactionsBatch.md
@@ -68,7 +68,7 @@ const config = {
 };
 
 // Generate EOA from private key using ethers.js
-let provider = new ethers.JsonRpcProvider(config.rpcUrl)();
+let provider = new ethers.JsonRpcProvider(config.rpcUrl);
 let signer = new ethers.Wallet(config.privateKey, provider);
 
 // Create Biconomy Smart Account instance

--- a/docs/tutorials/sendTransactionsBatch.md
+++ b/docs/tutorials/sendTransactionsBatch.md
@@ -68,7 +68,7 @@ const config = {
 };
 
 // Generate EOA from private key using ethers.js
-let provider = new ethers.JsonRpcProvider(config.rpcUrl);
+let provider = new ethers.providers.JsonRpcProvider(config.rpcUrl);
 let signer = new ethers.Wallet(config.privateKey, provider);
 
 // Create Biconomy Smart Account instance


### PR DESCRIPTION
Line `let provider = new ethers.JsonRpcProvider(config.rpcUrl)()` reports an error:

`This expression is not callable.
  Type 'JsonRpcProvider' has no call signatures.`
  
  It should be called without the parentheses. Check [JsonRpcProvider](https://docs.ethers.org/v5/api/providers/jsonrpc-provider/#JsonRpcProvider) for more info.