### PR TITLE
Quickstart word redundancy fix

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -52,7 +52,7 @@ The **Externally Owned Account (EOA)** corresponding to the private key will ser
 
 Create an index.ts file, copy the following code in it and replace the `PRIVATE_KEY`.
 
-> Be sure to never publicly expose your private key publicly.
+> Be sure to never publicly expose your private key.
 
 ```ts
 import {


### PR DESCRIPTION
Removing `publicly` at the end of the sentence improves clarity.