### PR TITLE
fix: fixing typo in smart account method getGasEstimate

### DIFF
--- a/docs/Account/methods.md
+++ b/docs/Account/methods.md
@@ -257,7 +257,7 @@ type SupportedToken = {
 };
 ```
 
-### [getGasEstimates()](https://bcnmy.github.io/biconomy-client-sdk/classes/BiconomySmartAccountV2.html#getGasEstimates)
+### [getGasEstimate()](https://bcnmy.github.io/biconomy-client-sdk/classes/BiconomySmartAccountV2.html#getGasEstimate)
 
 Get a gas estimate in wei for given tx(s)
 
@@ -280,7 +280,7 @@ const tx = {
   to: nftAddress,
   data: encodedCall,
 };
-const amountInWei = await smartAccount.getGasEstimates([tx, tx], {
+const amountInWei = await smartAccount.getGasEstimate([tx, tx], {
   paymasterServiceData: {
     mode: PaymasterMode.SPONSORED,
   },


### PR DESCRIPTION
For `smartAccountClient.getGasEstimates()` I'm getting error 

> Property 'getGasEstimates' does not exist on type 'BiconomySmartAccountV2'. Did you mean 'getGasEstimate'?