### PR TITLE
fix: rename parameter from bundler to EntryPoint address

### DIFF
--- a/docs/Bundler/api/estimate-useroperation-gas.md
+++ b/docs/Bundler/api/estimate-useroperation-gas.md
@@ -16,7 +16,7 @@ Body
 | Param   | Type   | Description                                                                                         | Required |
 | ------- | ------ | --------------------------------------------------------------------------------------------------- | -------- |
 | method  | string | Name of method in this case: eth_estimateUserOperationGas                                           | Required |
-| params  | array  | An array consisting of the Useroperation object, Bundler address and an optional State Override Set | Required |
+| params  | array  | An array consisting of the UserOperation object, EntryPoint contract address and an optional State Override Set | Required |
 | id      | string | id for request determined by client for JSON RPC requests                                           | Required |
 | jsonrpc | string | JSON RPC version in this case 2.0.0                                                                 | Required |
 


### PR DESCRIPTION

From the Bundlers repository on the master branch:

<img width="668" alt="Screenshot 2024-07-17 at 10 20 04" src="https://github.com/user-attachments/assets/2a1c98cf-b59a-4452-8bad-59ad83d8ebd0">
