### PR TITLE
Use ContractScan for cross-chain deployments

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -14,29 +14,29 @@ These contracts are deployed across all supported chains.
 | Contract Name                   | Address                                    |
 | ------------------------------- | ------------------------------------------ |
 | Entry point (chiliz mainnet & testnet) | [0x00000061FEfce24A79343c27127435286BB7A4E1](https://scan.chiliz.com/address/0x00000061FEfce24A79343c27127435286BB7A4E1/contracts#address-tabs) |
-| Entry point (all the other chains)      | 0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789 |
+| Entry point (all the other chains)      | [0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789](https://contractscan.xyz/contract/0x5ff137d4b0fdcd49dca30c7cf57e578a026d2789) |
 
 ## Smart Account
 
 | Contract Name                   | Address                                    |
 | ------------------------------- | ------------------------------------------ |
-| Smart Account Implementation V2 | 0x0000002512019Dafb59528B82CB92D3c5D2423aC |
-| Smart Account Factory V2        | 0x000000a56Aaca3e9a4C479ea6b6CD0DbcB6634F5 |
-| ECDSA Ownership Module          | 0x0000001c5b32F37F5beA87BDD5374eB2aC54eA8e |
-| Multichain Validation Module    | 0x000000824dc138db84FD9109fc154bdad332Aa8E |
-| Batched Session Router Module   | 0x00000D09967410f8C76752A104c9848b57ebba55 |
-| ABI Session Validation Module   | 0x000006bC2eCdAe38113929293d241Cf252D91861 |
-| Session Key Manager V1          | 0x000002FbFfedd9B33F4E7156F2DE8D48945E7489 |
-| Verifying Paymaster V1          | 0x000031DD6D9D3A133E663660b959162870D755D4 |
-| Verifying Paymaster V1.1.0      | 0x00000f79b7faf42eebadba19acc07cd08af44789 |
-| Token Paymaster                 | 0x00000f7365cA6C59A2C93719ad53d567ed49c14C |
+| Smart Account Implementation V2 | [0x0000002512019Dafb59528B82CB92D3c5D2423aC](https://contractscan.xyz/contract/0x0000002512019dafb59528b82cb92d3c5d2423ac) |
+| Smart Account Factory V2        | [0x000000a56Aaca3e9a4C479ea6b6CD0DbcB6634F5](https://contractscan.xyz/contract/0x000000a56aaca3e9a4c479ea6b6cd0dbcb6634f5) |
+| ECDSA Ownership Module          | [0x0000001c5b32F37F5beA87BDD5374eB2aC54eA8e](https://contractscan.xyz/contract/0x0000001c5b32f37f5bea87bdd5374eb2ac54ea8e) |
+| Multichain Validation Module    | [0x000000824dc138db84FD9109fc154bdad332Aa8E](https://contractscan.xyz/contract/0x000000824dc138db84fd9109fc154bdad332aa8e) |
+| Batched Session Router Module   | [0x00000D09967410f8C76752A104c9848b57ebba55](https://contractscan.xyz/contract/0x00000d09967410f8c76752a104c9848b57ebba55) |
+| ABI Session Validation Module   | [0x000006bC2eCdAe38113929293d241Cf252D91861](https://contractscan.xyz/contract/0x000006bc2ecdae38113929293d241cf252d91861) |
+| Session Key Manager V1          | [0x000002FbFfedd9B33F4E7156F2DE8D48945E7489](https://contractscan.xyz/contract/0x000002fbffedd9b33f4e7156f2de8d48945e7489) |
+| Verifying Paymaster V1          | [0x000031DD6D9D3A133E663660b959162870D755D4](https://contractscan.xyz/contract/0x000031dd6d9d3a133e663660b959162870d755d4) |
+| Verifying Paymaster V1.1.0      | [0x00000f79b7faf42eebadba19acc07cd08af44789](https://contractscan.xyz/contract/0x00000f79b7faf42eebadba19acc07cd08af44789) |
+| Token Paymaster                 | [0x00000f7365cA6C59A2C93719ad53d567ed49c14C](https://contractscan.xyz/contract/0x00000f7365ca6c59a2c93719ad53d567ed49c14c) |
 
 ## Legacy: Smart Account V1
 
 | Contract Name                | Address                                    |
 | ---------------------------- | ------------------------------------------ |
-| Smart Account Implementation V1 | 0x00006B7e42e01957dA540Dc6a8F7C30c4D816af5 |
-| Smart Account Factory V1        | 0x000000F9eE1842Bb72F6BBDD75E6D3d4e3e9594C |
+| Smart Account Implementation V1 | [0x00006B7e42e01957dA540Dc6a8F7C30c4D816af5](https://contractscan.xyz/contract/0x00006b7e42e01957da540dc6a8f7c30c4d816af5) |
+| Smart Account Factory V1        | [0x000000F9eE1842Bb72F6BBDD75E6D3d4e3e9594C](https://contractscan.xyz/contract/0x000000f9ee1842bb72f6bbdd75e6d3d4e3e9594c) |
 
 ## Blast Gold Addresses
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -42,8 +42,8 @@ These contracts are deployed across all supported chains.
 
 | Contract Name                | Address                                    |
 | ---------------------------- | ------------------------------------------ |
-| Points Operator address | 0xfe867385e5C7CC9d0C00F2D80719f8Cb7836E3f2 |
-| Deployed Smart Contract | 0x7f4FB6A17A84aAc3e16BbC0C8d03Ca563aB0c483 |
+| Points Operator address | [0xfe867385e5C7CC9d0C00F2D80719f8Cb7836E3f2](https://blastscan.io/address/0xfe867385e5C7CC9d0C00F2D80719f8Cb7836E3f2) |
+| Deployed Smart Contract | [0x7f4FB6A17A84aAc3e16BbC0C8d03Ca563aB0c483](https://blastscan.io/address/0x7f4FB6A17A84aAc3e16BbC0C8d03Ca563aB0c483) |
 <!-- Chirag to confirm
 | Gas Estimator                | 0x984a2441A196bf03d85fce4fe8c7A211249eDaAf |
 | Decoder                      | 0x8acd02fe897e5a98f5287Be9ee95d5feE74311B0 |


### PR DESCRIPTION
Adds links for multi-chain contract deployments using [ContractScan](https://contractscan.xyz). It scans 100+ EVM networks to make a list of chains where the contract is deployed.

I also added links to BlastScan for Blast-specific contracts.

> Disclaimer: I am the author of the tool